### PR TITLE
When_two_servers_sends_messages_through_a_junction fixture looked incorrect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ AutoTest.config.old
 *_mm_cache.bin
 *~
 *.swp
+
+/AutoTest.NET.sln.DotSettings.user

--- a/src/AutoTest.TestRunner/AutoTest.TestRunners.Tests/Communication/When_two_servers_sends_messages_through_a_junction.cs
+++ b/src/AutoTest.TestRunner/AutoTest.TestRunners.Tests/Communication/When_two_servers_sends_messages_through_a_junction.cs
@@ -27,7 +27,7 @@ namespace AutoTest.TestRunners.Tests.Communication
                         junction.Combine(pipe1);
                         junction.Combine(pipe2);
                         server1.Send("Message from server 1");
-                        server1.Send("Message from server 2");
+                        server2.Send("Message from server 2");
 
                         var messages = new List<string>();
                         var client = new PipeClient();


### PR DESCRIPTION
Issue: The test was sending from the same server object. 

Resolution: Altered the test to use server1 and then server2
