### PR TITLE
Updates for OSX - operating system value is not being honored

### DIFF
--- a/src/AutoTest.Core/OperatingSystem/OS.cs
+++ b/src/AutoTest.Core/OperatingSystem/OS.cs
@@ -41,9 +41,9 @@ namespace AutoTest
 
         public static bool IsOSX {
             get {
-                if (_isUnix == null)
+                if (_isOSX == null)
                     setUnixAndLinux();
-                return (bool) _isUnix;
+                return (bool) _isOSX;
             }
         }
 

--- a/src/AutoTest.Test/Core/FileSystem/WatchValidatorTest.cs
+++ b/src/AutoTest.Test/Core/FileSystem/WatchValidatorTest.cs
@@ -218,17 +218,17 @@ namespace AutoTest.Test.Core.FileSystem
                 return;
 			_configuration.Stub(c => c.ShouldUseBinaryChangeIgnoreLists).Return(false);
 			_configuration.Stub(c => c.WatchIgnoreList).Return(new string[] { "myFolder/*" });
-			_validator.ShouldPublish("/Somedirectory/hoi/myfolder/somexmlfile.xml").ShouldBeTrue();
+			_validator.ShouldPublish("/Somedirectory/hoi/myfolder/somexmlfile.xml").ShouldBeFalse();
 		}
 
         [Test]
-        public void Should_not_glob_case_sensitive_on_non_unix_platforms()
+        public void Should_glob_case_insensitive_on_non_unix_platforms()
         {
-            if (!OS.IsPosix)
+            if (OS.IsPosix)
                 return;
             _configuration.Stub(c => c.ShouldUseBinaryChangeIgnoreLists).Return(false);
             _configuration.Stub(c => c.WatchIgnoreList).Return(new string[] { "myFolder/*" });
-            _validator.ShouldPublish("/Somedirectory/hoi/myfolder/somexmlfile.xml").ShouldBeFalse();
+            _validator.ShouldPublish("/Somedirectory/hoi/myfolder/somexmlfile.xml").ShouldBeTrue();
         }
 		
 		[Test]

--- a/src/AutoTest.TestRunner/AutoTest.TestRunners.Shared/AutoTest.TestRunners.Shared.csproj
+++ b/src/AutoTest.TestRunner/AutoTest.TestRunners.Shared/AutoTest.TestRunners.Shared.csproj
@@ -145,7 +145,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/AutoTest.TestRunners.Tests/AutoTest.TestRunners.Tests.csproj
+++ b/src/AutoTest.TestRunner/AutoTest.TestRunners.Tests/AutoTest.TestRunners.Tests.csproj
@@ -153,7 +153,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/AutoTest.TestRunners/AutoTest.TestRunners.csproj
+++ b/src/AutoTest.TestRunner/AutoTest.TestRunners/AutoTest.TestRunners.csproj
@@ -125,7 +125,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSTest.Tests/AutoTest.TestRunners.MSTest.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSTest.Tests/AutoTest.TestRunners.MSTest.Tests.csproj
@@ -127,7 +127,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSTest/AutoTest.TestRunners.MSTest.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSTest/AutoTest.TestRunners.MSTest.csproj
@@ -124,7 +124,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec.Tests.TestResource/AutoTest.TestRunners.MSpec.Tests.TestResource.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec.Tests.TestResource/AutoTest.TestRunners.MSpec.Tests.TestResource.csproj
@@ -84,7 +84,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec.Tests/AutoTest.TestRunners.MSpec.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec.Tests/AutoTest.TestRunners.MSpec.Tests.csproj
@@ -94,7 +94,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec/AutoTest.TestRunners.MSpec.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MSpec/AutoTest.TestRunners.MSpec.csproj
@@ -108,7 +108,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit.Tests.TestResource/AutoTest.TestRunners.MbUnit.Tests.TestResource.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit.Tests.TestResource/AutoTest.TestRunners.MbUnit.Tests.TestResource.csproj
@@ -83,7 +83,7 @@
     <Compile Include="ClassContainingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit.Tests/AutoTest.TestRunners.MbUnit.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit.Tests/AutoTest.TestRunners.MbUnit.Tests.csproj
@@ -94,7 +94,7 @@
       <Name>AutoTest.TestRunners.MbUnit</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit/AutoTest.TestRunners.MbUnit.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.MbUnit/AutoTest.TestRunners.MbUnit.csproj
@@ -126,7 +126,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit.Tests.TestResource/AutoTest.TestRunners.NUnit.Tests.TestResource.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit.Tests.TestResource/AutoTest.TestRunners.NUnit.Tests.TestResource.csproj
@@ -116,7 +116,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit.Tests/AutoTest.TestRunners.NUnit.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit.Tests/AutoTest.TestRunners.NUnit.Tests.csproj
@@ -129,7 +129,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit/AutoTest.TestRunners.NUnit.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.NUnit/AutoTest.TestRunners.NUnit.csproj
@@ -132,7 +132,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting.Tests.Resources/AutoTest.TestRunners.SimpleTesting.Tests.Resources.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting.Tests.Resources/AutoTest.TestRunners.SimpleTesting.Tests.Resources.csproj
@@ -80,7 +80,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting.Tests/AutoTest.TestRunners.SimpleTesting.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting.Tests/AutoTest.TestRunners.SimpleTesting.Tests.csproj
@@ -94,7 +94,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting/AutoTest.TestRunners.SimpleTesting.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.SimpleTesting/AutoTest.TestRunners.SimpleTesting.csproj
@@ -86,7 +86,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit.Tests.TestResource/AutoTest.TestRunners.XUnit.Tests.TestResource.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit.Tests.TestResource/AutoTest.TestRunners.XUnit.Tests.TestResource.csproj
@@ -117,7 +117,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit.Tests/AutoTest.TestRunners.XUnit.Tests.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit.Tests/AutoTest.TestRunners.XUnit.Tests.csproj
@@ -129,7 +129,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit/AutoTest.TestRunners.XUnit.csproj
+++ b/src/AutoTest.TestRunner/Plugins/AutoTest.TestRunners.XUnit/AutoTest.TestRunners.XUnit.csproj
@@ -121,7 +121,6 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/AutoTest.TestRunner/Plugins/Microsoft.VisualStudio.QualityTools.UnitTestFramework/Microsoft.VisualStudio.QualityTools.UnitTestFramework.csproj
+++ b/src/AutoTest.TestRunner/Plugins/Microsoft.VisualStudio.QualityTools.UnitTestFramework/Microsoft.VisualStudio.QualityTools.UnitTestFramework.csproj
@@ -140,7 +140,7 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Currently, the AutoTest.Core OperatingSystem class is not correctly handing OSX.

This prevents all the tests from passing and of course causes other operating system-specific problems (such as GrowlNotify being called incorrectly). The issue also affects Mighty Moose.

I have included a commit that removes a redundant Microsoft.CSharp.targets import during build of many of the TestRunners projects. XBuild (2.10.9.0) fails when trying to bring in the second targets file.
